### PR TITLE
Iss9

### DIFF
--- a/lib/index.coffee
+++ b/lib/index.coffee
@@ -128,8 +128,7 @@ class TwitterPosts extends Readable
           )
 
         pics = $(element).find(
-          '.multi-photos .multi-photo[data-image-url],
-          [data-card-type=photo] [data-image-url]'
+          '.AdaptiveMedia-container .AdaptiveMedia-photoContainer[data-image-url]'
         )
         for pic in pics
           post.images.push $(pic).attr('data-image-url')

--- a/test/index.coffee
+++ b/test/index.coffee
@@ -32,3 +32,9 @@ describe 'tweet stream', ->
       tweet.time.should.be.an.instanceOf(Number)
       (tweet.time > year2000).should.be.true
       (tweet.time < year3000).should.be.true # twitter should be dead by then
+
+  it 'should grab photo url(s) for a tweet if it has a photo', ->
+    # we know a tweet has a photo if a tweet's text contains 'pic.twitter.com'
+    # unfortunately this test will fail if a video is present in a tweet
+    for tweet in @tweets
+      tweet.images.length.should.be.above(0) if tweet.text.indexOf('pic.twitter.com') > -1


### PR DESCRIPTION
Fixes #9 
Updates the part of the script that looks for images. adds a test for finding images, but the test will fail if a video is present in the tweet instead of a photo.